### PR TITLE
No plural list

### DIFF
--- a/src/pymachine/definition_parser.py
+++ b/src/pymachine/definition_parser.py
@@ -282,8 +282,7 @@ class DefinitionParser(object):
                 unified = __get_unified(machines_to_unify)
             __replace(machine, unified, is_other)
 
-    def __parse_expr(self, expr, root, loop_to_defendum=True,
-                     three_parts=False):
+    def __parse_expr(self, expr, root, loop_to_defendum=True):
         """
         creates machines from a parse node and its children
         there should be one handler for every rule
@@ -298,9 +297,9 @@ class DefinitionParser(object):
         is_unary = cls._is_unary
         is_tree = lambda r: type(r) == list
 
-        left_part = 0 + int(three_parts)
-        right_part = 1 + int(three_parts)
-        most_part = 2 + int(three_parts)
+        most_part = 0
+        left_part = 1
+        right_part = 2
 
         if (len(expr) == 1):
             # UE -> U
@@ -311,8 +310,7 @@ class DefinitionParser(object):
             # E -> UE | BE, A -> UE
             if (is_tree(expr[0])):
                 logging.debug("Parsing {0} as a tree.".format(expr[0]))
-                return self.__parse_expr(expr[0], root, loop_to_defendum,
-                                         three_parts)
+                return self.__parse_expr(expr[0], root, loop_to_defendum)
 
         if (len(expr) == 2):
             # BE -> A B
@@ -321,8 +319,7 @@ class DefinitionParser(object):
                 m = self.create_machine(expr[1], most_part)
                 if expr[0] != ["'"]:
                     m.append_all(
-                        self.__parse_expr(expr[0], root, loop_to_defendum,
-                                          three_parts),
+                        self.__parse_expr(expr[0], root, loop_to_defendum),
                         left_part)
                 if loop_to_defendum:
                     m.append(root, right_part)
@@ -334,8 +331,7 @@ class DefinitionParser(object):
                 m = self.create_machine(expr[0], most_part)
                 if expr[1] != ["'"]:
                     m.append_all(
-                        self.__parse_expr(expr[1], root, loop_to_defendum,
-                                          three_parts),
+                        self.__parse_expr(expr[1], root, loop_to_defendum),
                         right_part)
                 if loop_to_defendum:
                     m.append(root, left_part)
@@ -385,13 +381,11 @@ class DefinitionParser(object):
                 if expr[0] != [DefinitionParser.prime]:
                     logging.debug(expr[0])
                     m.append_all(
-                        self.__parse_expr(expr[0], root, loop_to_defendum,
-                                          three_parts),
+                        self.__parse_expr(expr[0], root, loop_to_defendum),
                         left_part)
                 if expr[2] != [DefinitionParser.prime]:
                     m.append_all(
-                        self.__parse_expr(expr[2], root, loop_to_defendum,
-                                          three_parts),
+                        self.__parse_expr(expr[2], root, loop_to_defendum),
                         right_part)
                 return [m]
 
@@ -402,15 +396,13 @@ class DefinitionParser(object):
                 logging.debug(
                     "Parsing expr {0} as an embedded definition".format(expr))
                 res = list(
-                    self.__parse_definition(expr[1], root, loop_to_defendum,
-                                            three_parts))
+                    self.__parse_definition(expr[1], root, loop_to_defendum))
                 return res
 
             # E -> < E >, U -> < U >
             if expr[0] == '<' and expr[2] == '>':
                 logging.debug('E -> < E >' + str(expr[1]))
-                return list(self.__parse_expr(expr[1], root, loop_to_defendum,
-                                              three_parts))
+                return list(self.__parse_expr(expr[1], root, loop_to_defendum))
 
         if (len(expr) == 4):
             # UE -> U ( U )
@@ -422,12 +414,7 @@ class DefinitionParser(object):
                 if is_unary(expr[2]):
                     m = self.create_machine(expr[2], 1)
                 else:
-                    m = self.__parse_expr(expr[2], root, loop_to_defendum,
-                                          three_parts)[0]
-                    if not three_parts:
-                        logging.warning(
-                            "for 0th partition of binary machines, " +
-                            "set three_parts=True, "+str(expr))
+                    m = self.__parse_expr(expr[2], root, loop_to_defendum)[0]
                 m.append(self.create_machine(expr[0], 1), 0)
                 return [m]
 
@@ -438,8 +425,7 @@ class DefinitionParser(object):
                     expr[3] == "]"):
                 m = self.create_machine(expr[0], 1)
                 for parsed_expr in self.__parse_definition(expr[2], root,
-                                                           loop_to_defendum,
-                                                           three_parts):
+                                                           loop_to_defendum):
                     m.append(parsed_expr, 0)
                 return [m]
 
@@ -448,8 +434,7 @@ class DefinitionParser(object):
             #        expr[1] == "(" and
             #        is_tree(expr[2]) and
             #        expr[3] == ")"):
-            #    ms = self.__parse_expr(expr[2], root, loop_to_defendum,
-            #                           three_parts)
+            #    ms = self.__parse_expr(expr[2], root, loop_to_defendum, #                           three_parts)
             #    # if BE was an expression with an apostrophe, then
             #    # return of __parse_expr() is None
             #    if len(ms) != 0:
@@ -472,12 +457,10 @@ class DefinitionParser(object):
                     expr[5] == "]"):
                 m = self.create_machine(expr[0], 2)
                 m.append_all(
-                    self.__parse_expr(expr[2], m, root, loop_to_defendum,
-                                      three_parts),
+                    self.__parse_expr(expr[2], m, root, loop_to_defendum),
                     0)
                 m.append_all(
-                    self.__parse_expr(expr[4], m, root, loop_to_defendum,
-                                      three_parts),
+                    self.__parse_expr(expr[4], m, root, loop_to_defendum),
                     1)
                 return [m]
 
@@ -489,52 +472,54 @@ class DefinitionParser(object):
         logging.debug(expr)
         raise pe
 
-    def __parse_definition(self, definition, root, loop_to_defendum=True,
-                           three_parts=True):
+    def __parse_definition(self, definition, root, loop_to_defendum=True):
         logging.debug(str(definition))
         for d in definition:
-            yield self.__parse_expr(d, root, loop_to_defendum, three_parts)[0]
+            yield self.__parse_expr(d, root, loop_to_defendum)[0]
 
-    def parse_into_machines(self, string, printname_index=0, add_indices=False,
-                            loop_to_defendum=True, three_parts=False):
-        printname = string.split('\t')[printname_index]
-        try:
-            id_, urob, pos, def_, comment = string.split('\t')[4:]
-        except:
-            raise Exception("Wrong number of fields in {}".format(string))
+    def parse_into_machines(self, printname, id_, def_, add_indices=False,
+                            loop_to_defendum=True):
 
         machine = self.create_machine(printname.lower(), 1)
-        #TODO =AGT -> partition 1, =PAT -> partition 2, =TO -> ?
 
         if add_indices:
             machine.printname_ = machine.printname() + id_sep + id_
 
-        if def_ != '':
-            logging.debug(def_)
-            parsed = self.parse(def_)
-            logging.debug(parsed)
-            for parsed_expr in self.__parse_definition(
-                    parsed[0], machine, loop_to_defendum, three_parts):
-                machine.append(parsed_expr, 0)
+        #if def_ != '':
+        logging.debug(def_)
+        parsed = self.parse(def_)
+        logging.debug(parsed)
+        for parsed_expr in self.__parse_definition(
+                parsed[0], machine, loop_to_defendum):
+            machine.append(parsed_expr, 0)
 
         self.unify(machine)
         return machine
 
-def read_lexicon(f, def_parser, printname_index=0, add_indices=False,
-         loop_to_defendum=True, three_parts=False):
+def read_lexicon(f, def_parser, language_index=0, add_indices=False,
+                 loop_to_defendum=True):
     for line in f:
-        l = line.strip('\n')
-        logging.debug("Parsing: {0}".format(l))
+        fields = line.strip('\n').split('\t')
+        if len(fields) != 9:
+            logging.warning(
+                "Wrong number of fields ({}) in {}".format(len(fields), fields))
+            continue
+        forms_in_langs = fields[:4] 
+        id_, dv, pos, def_, comment = fields[4:]
+        if not def_:
+            continue
+        logging.debug("Parsing: {0}".format(line))
+        printname = forms_in_langs[language_index]
         try:
-            m = def_parser.parse_into_machines(l, printname_index, add_indices,
-                                       loop_to_defendum, three_parts)
+            m = def_parser.parse_into_machines(printname, id_, def_,
+                                               add_indices, loop_to_defendum)
             if m.partitions[0] == []:
                 logging.debug('dropping empty definition of '+m.printname())
                 continue
-            pn = m.printname()
-            yield m.to_debug_str()
+            yield m
         except pyparsing.ParseException, pe:
-            logging.error('Cannot parse {} in {}: '.format(pe, l))
+            logging.error('Cannot parse {}/{}: {}\n{}'.format(printname, id_,
+                                                              def_, pe))
 
 
 def parse_args(): 
@@ -546,18 +531,18 @@ def parse_args():
     parser.add_argument('-d', '--debug_machine', action='store_true')
     return parser.parse_args()
 
+
 if __name__ == "__main__":
     format_ = "%(asctime)s: %(module)s (%(lineno)s) %(levelname)s %(message)s"
-    logging.basicConfig(level=logging.WARNING, format=format_)
+    logging.basicConfig(level=logging.INFO, format=format_)
     args = parse_args()
     def_parser = DefinitionParser()
     if args.singe_formula:
-        machine_iterable = [def_parser.parse_into_machines(
-            args.formula_or_lexicon)]
+        machine_iterable = [
+            def_parser.parse_into_machines(args.formula_or_lexicon)]
     else:
         machine_iterable = read_lexicon(file(args.formula_or_lexicon), def_parser)
     # in some third case: print def_parser.parse(args.formula_or_lexicon)
     if args.debug_machine:
         for machine in machine_iterable:
             print Machine.to_debug_str(machine)
-

--- a/src/pymachine/definition_parser.py
+++ b/src/pymachine/definition_parser.py
@@ -543,6 +543,7 @@ if __name__ == "__main__":
     else:
         machine_iterable = read_lexicon(file(args.formula_or_lexicon), def_parser)
     # in some third case: print def_parser.parse(args.formula_or_lexicon)
-    if args.debug_machine:
-        for machine in machine_iterable:
-            print Machine.to_debug_str(machine)
+    for machine in machine_iterable:
+        debug_str = Machine.to_debug_str(machine)
+        if args.debug_machine:
+            print debug_str


### PR DESCRIPTION
Until now, (manual) 4lang definitions have been allowed to contain plural nouns, that have had special treatment when parsing to machines: `women` was parsed to `woman -0-> more`. There has been a file in the 4lang repo (4lang/4lang.plural), that told which nouns are plurals, and what their singulars are. Now I rewrote definitions such that the (semantic) number is specified directly. I submit this update in more requests: this one, and in the 4lang repo.
Some other changes in this request: three partitions are burned in the code (they have been optional), and I slightly refactored the outer (wrapper) functions.
@recski 