### PR TITLE
Definition parser

### DIFF
--- a/src/pymachine/definition_parser.py
+++ b/src/pymachine/definition_parser.py
@@ -434,7 +434,7 @@ class DefinitionParser(object):
             #        expr[1] == "(" and
             #        is_tree(expr[2]) and
             #        expr[3] == ")"):
-            #    ms = self.__parse_expr(expr[2], root, loop_to_defendum, #                           three_parts)
+            #    ms = self.__parse_expr(expr[2], root, loop_to_defendum)
             #    # if BE was an expression with an apostrophe, then
             #    # return of __parse_expr() is None
             #    if len(ms) != 0:
@@ -496,7 +496,7 @@ class DefinitionParser(object):
         self.unify(machine)
         return machine
 
-def read_lexicon(f, def_parser, language_index=0, add_indices=False,
+def read_defs(f, def_parser, language_index=0, add_indices=False,
                  loop_to_defendum=True):
     for line in f:
         fields = line.strip('\n').split('\t')
@@ -541,7 +541,7 @@ if __name__ == "__main__":
         machine_iterable = [
             def_parser.parse_into_machines(args.formula_or_lexicon)]
     else:
-        machine_iterable = read_lexicon(file(args.formula_or_lexicon), def_parser)
+        machine_iterable = read_defs(file(args.formula_or_lexicon), def_parser)
     # in some third case: print def_parser.parse(args.formula_or_lexicon)
     for machine in machine_iterable:
         debug_str = Machine.to_debug_str(machine)

--- a/src/pymachine/definition_parser.py
+++ b/src/pymachine/definition_parser.py
@@ -496,8 +496,8 @@ class DefinitionParser(object):
         self.unify(machine)
         return machine
 
-def read_defs(f, def_parser, language_index=0, add_indices=False,
-                 loop_to_defendum=True):
+def read_defs(f, language_index=0, add_indices=False, loop_to_defendum=True):
+    def_parser = DefinitionParser()
     for line in f:
         fields = line.strip('\n').split('\t')
         if len(fields) != 9:
@@ -536,8 +536,8 @@ if __name__ == "__main__":
     format_ = "%(asctime)s: %(module)s (%(lineno)s) %(levelname)s %(message)s"
     logging.basicConfig(level=logging.INFO, format=format_)
     args = parse_args()
-    def_parser = DefinitionParser()
     if args.singe_formula:
+        def_parser = DefinitionParser()
         machine_iterable = [
             def_parser.parse_into_machines('NO PRINTNAME', 'NO ID', args.formula_or_lexicon)]
     else:

--- a/src/pymachine/definition_parser.py
+++ b/src/pymachine/definition_parser.py
@@ -541,7 +541,7 @@ if __name__ == "__main__":
         machine_iterable = [
             def_parser.parse_into_machines('NO PRINTNAME', 'NO ID', args.formula_or_lexicon)]
     else:
-        machine_iterable = read_defs(file(args.formula_or_lexicon), def_parser)
+        machine_iterable = read_defs(file(args.formula_or_lexicon))
     # in some third case: print def_parser.parse(args.formula_or_lexicon)
     for machine in machine_iterable:
         debug_str = Machine.to_debug_str(machine)

--- a/src/pymachine/definition_parser.py
+++ b/src/pymachine/definition_parser.py
@@ -282,8 +282,7 @@ class DefinitionParser(object):
                 unified = __get_unified(machines_to_unify)
             __replace(machine, unified, is_other)
 
-    def __parse_expr(self, expr, root, loop_to_defendum=True,
-                     three_parts=False):
+    def __parse_expr(self, expr, root, loop_to_defendum=True):
         """
         creates machines from a parse node and its children
         there should be one handler for every rule
@@ -298,9 +297,9 @@ class DefinitionParser(object):
         is_unary = cls._is_unary
         is_tree = lambda r: type(r) == list
 
-        left_part = 0 + int(three_parts)
-        right_part = 1 + int(three_parts)
-        most_part = 2 + int(three_parts)
+        most_part = 0
+        left_part = 1
+        right_part = 2
 
         if (len(expr) == 1):
             # UE -> U
@@ -311,8 +310,7 @@ class DefinitionParser(object):
             # E -> UE | BE, A -> UE
             if (is_tree(expr[0])):
                 logging.debug("Parsing {0} as a tree.".format(expr[0]))
-                return self.__parse_expr(expr[0], root, loop_to_defendum,
-                                         three_parts)
+                return self.__parse_expr(expr[0], root, loop_to_defendum)
 
         if (len(expr) == 2):
             # BE -> A B
@@ -321,8 +319,7 @@ class DefinitionParser(object):
                 m = self.create_machine(expr[1], most_part)
                 if expr[0] != ["'"]:
                     m.append_all(
-                        self.__parse_expr(expr[0], root, loop_to_defendum,
-                                          three_parts),
+                        self.__parse_expr(expr[0], root, loop_to_defendum),
                         left_part)
                 if loop_to_defendum:
                     m.append(root, right_part)
@@ -334,8 +331,7 @@ class DefinitionParser(object):
                 m = self.create_machine(expr[0], most_part)
                 if expr[1] != ["'"]:
                     m.append_all(
-                        self.__parse_expr(expr[1], root, loop_to_defendum,
-                                          three_parts),
+                        self.__parse_expr(expr[1], root, loop_to_defendum),
                         right_part)
                 if loop_to_defendum:
                     m.append(root, left_part)
@@ -385,13 +381,11 @@ class DefinitionParser(object):
                 if expr[0] != [DefinitionParser.prime]:
                     logging.debug(expr[0])
                     m.append_all(
-                        self.__parse_expr(expr[0], root, loop_to_defendum,
-                                          three_parts),
+                        self.__parse_expr(expr[0], root, loop_to_defendum),
                         left_part)
                 if expr[2] != [DefinitionParser.prime]:
                     m.append_all(
-                        self.__parse_expr(expr[2], root, loop_to_defendum,
-                                          three_parts),
+                        self.__parse_expr(expr[2], root, loop_to_defendum),
                         right_part)
                 return [m]
 
@@ -402,15 +396,13 @@ class DefinitionParser(object):
                 logging.debug(
                     "Parsing expr {0} as an embedded definition".format(expr))
                 res = list(
-                    self.__parse_definition(expr[1], root, loop_to_defendum,
-                                            three_parts))
+                    self.__parse_definition(expr[1], root, loop_to_defendum))
                 return res
 
             # E -> < E >, U -> < U >
             if expr[0] == '<' and expr[2] == '>':
                 logging.debug('E -> < E >' + str(expr[1]))
-                return list(self.__parse_expr(expr[1], root, loop_to_defendum,
-                                              three_parts))
+                return list(self.__parse_expr(expr[1], root, loop_to_defendum))
 
         if (len(expr) == 4):
             # UE -> U ( U )
@@ -422,12 +414,7 @@ class DefinitionParser(object):
                 if is_unary(expr[2]):
                     m = self.create_machine(expr[2], 1)
                 else:
-                    m = self.__parse_expr(expr[2], root, loop_to_defendum,
-                                          three_parts)[0]
-                    if not three_parts:
-                        logging.warning(
-                            "for 0th partition of binary machines, " +
-                            "set three_parts=True, "+str(expr))
+                    m = self.__parse_expr(expr[2], root, loop_to_defendum)[0]
                 m.append(self.create_machine(expr[0], 1), 0)
                 return [m]
 
@@ -438,8 +425,7 @@ class DefinitionParser(object):
                     expr[3] == "]"):
                 m = self.create_machine(expr[0], 1)
                 for parsed_expr in self.__parse_definition(expr[2], root,
-                                                           loop_to_defendum,
-                                                           three_parts):
+                                                           loop_to_defendum):
                     m.append(parsed_expr, 0)
                 return [m]
 
@@ -448,8 +434,7 @@ class DefinitionParser(object):
             #        expr[1] == "(" and
             #        is_tree(expr[2]) and
             #        expr[3] == ")"):
-            #    ms = self.__parse_expr(expr[2], root, loop_to_defendum,
-            #                           three_parts)
+            #    ms = self.__parse_expr(expr[2], root, loop_to_defendum, #                           three_parts)
             #    # if BE was an expression with an apostrophe, then
             #    # return of __parse_expr() is None
             #    if len(ms) != 0:
@@ -472,12 +457,10 @@ class DefinitionParser(object):
                     expr[5] == "]"):
                 m = self.create_machine(expr[0], 2)
                 m.append_all(
-                    self.__parse_expr(expr[2], m, root, loop_to_defendum,
-                                      three_parts),
+                    self.__parse_expr(expr[2], m, root, loop_to_defendum),
                     0)
                 m.append_all(
-                    self.__parse_expr(expr[4], m, root, loop_to_defendum,
-                                      three_parts),
+                    self.__parse_expr(expr[4], m, root, loop_to_defendum),
                     1)
                 return [m]
 
@@ -489,52 +472,54 @@ class DefinitionParser(object):
         logging.debug(expr)
         raise pe
 
-    def __parse_definition(self, definition, root, loop_to_defendum=True,
-                           three_parts=True):
+    def __parse_definition(self, definition, root, loop_to_defendum=True):
         logging.debug(str(definition))
         for d in definition:
-            yield self.__parse_expr(d, root, loop_to_defendum, three_parts)[0]
+            yield self.__parse_expr(d, root, loop_to_defendum)[0]
 
-    def parse_into_machines(self, string, printname_index=0, add_indices=False,
-                            loop_to_defendum=True, three_parts=False):
-        printname = string.split('\t')[printname_index]
-        try:
-            id_, urob, pos, def_, comment = string.split('\t')[4:]
-        except:
-            raise Exception("Wrong number of fields in {}".format(string))
+    def parse_into_machines(self, printname, id_, def_, add_indices=False,
+                            loop_to_defendum=True):
 
         machine = self.create_machine(printname.lower(), 1)
-        #TODO =AGT -> partition 1, =PAT -> partition 2, =TO -> ?
 
         if add_indices:
             machine.printname_ = machine.printname() + id_sep + id_
 
-        if def_ != '':
-            logging.debug(def_)
-            parsed = self.parse(def_)
-            logging.debug(parsed)
-            for parsed_expr in self.__parse_definition(
-                    parsed[0], machine, loop_to_defendum, three_parts):
-                machine.append(parsed_expr, 0)
+        #if def_ != '':
+        logging.debug(def_)
+        parsed = self.parse(def_)
+        logging.debug(parsed)
+        for parsed_expr in self.__parse_definition(
+                parsed[0], machine, loop_to_defendum):
+            machine.append(parsed_expr, 0)
 
         self.unify(machine)
         return machine
 
-def read_lexicon(f, def_parser, printname_index=0, add_indices=False,
-         loop_to_defendum=True, three_parts=False):
+def read_lexicon(f, def_parser, language_index=0, add_indices=False,
+                 loop_to_defendum=True):
     for line in f:
-        l = line.strip('\n')
-        logging.debug("Parsing: {0}".format(l))
+        fields = line.strip('\n').split('\t')
+        if len(fields) != 9:
+            logging.warning(
+                "Wrong number of fields ({}) in {}".format(len(fields), fields))
+            continue
+        forms_in_langs = fields[:4] 
+        id_, dv, pos, def_, comment = fields[4:]
+        if not def_:
+            continue
+        logging.debug("Parsing: {0}".format(line))
+        printname = forms_in_langs[language_index]
         try:
-            m = def_parser.parse_into_machines(l, printname_index, add_indices,
-                                       loop_to_defendum, three_parts)
+            m = def_parser.parse_into_machines(printname, id_, def_,
+                                               add_indices, loop_to_defendum)
             if m.partitions[0] == []:
                 logging.debug('dropping empty definition of '+m.printname())
                 continue
-            pn = m.printname()
-            yield m.to_debug_str()
+            yield m
         except pyparsing.ParseException, pe:
-            logging.error('Cannot parse {} in {}: '.format(pe, l))
+            logging.error('Cannot parse {}/{}: {}\n{}'.format(printname, id_,
+                                                              def_, pe))
 
 
 def parse_args(): 
@@ -546,18 +531,18 @@ def parse_args():
     parser.add_argument('-d', '--debug_machine', action='store_true')
     return parser.parse_args()
 
+
 if __name__ == "__main__":
     format_ = "%(asctime)s: %(module)s (%(lineno)s) %(levelname)s %(message)s"
-    logging.basicConfig(level=logging.WARNING, format=format_)
+    logging.basicConfig(level=logging.INFO, format=format_)
     args = parse_args()
     def_parser = DefinitionParser()
     if args.singe_formula:
-        machine_iterable = [def_parser.parse_into_machines(
-            args.formula_or_lexicon)]
+        machine_iterable = [
+            def_parser.parse_into_machines(args.formula_or_lexicon)]
     else:
         machine_iterable = read_lexicon(file(args.formula_or_lexicon), def_parser)
     # in some third case: print def_parser.parse(args.formula_or_lexicon)
     if args.debug_machine:
         for machine in machine_iterable:
             print Machine.to_debug_str(machine)
-

--- a/src/pymachine/definition_parser.py
+++ b/src/pymachine/definition_parser.py
@@ -498,6 +498,7 @@ class DefinitionParser(object):
 
 def read_defs(f, language_index=0, add_indices=False, loop_to_defendum=True):
     def_parser = DefinitionParser()
+    d = defaultdict(set)
     for line in f:
         fields = line.strip('\n').split('\t')
         if len(fields) != 9:
@@ -523,7 +524,7 @@ def read_defs(f, language_index=0, add_indices=False, loop_to_defendum=True):
                 #    pn, d[pn], "{0}:{1}".format(m, m.partitions)))
             d[pn].add(m)
             logging.debug('\n'+m.to_debug_str())
-            yield m
+            yield pn, d[pn]
         except pyparsing.ParseException, pe:
             logging.error('Cannot parse {}/{}: {}\n{}'.format(printname, id_,
                                                               def_, pe))

--- a/src/pymachine/definition_parser.py
+++ b/src/pymachine/definition_parser.py
@@ -539,7 +539,7 @@ if __name__ == "__main__":
     def_parser = DefinitionParser()
     if args.singe_formula:
         machine_iterable = [
-            def_parser.parse_into_machines(args.formula_or_lexicon)]
+            def_parser.parse_into_machines('NO PRINTNAME', 'NO ID', args.formula_or_lexicon)]
     else:
         machine_iterable = read_defs(file(args.formula_or_lexicon), def_parser)
     # in some third case: print def_parser.parse(args.formula_or_lexicon)

--- a/src/pymachine/definition_parser.py
+++ b/src/pymachine/definition_parser.py
@@ -543,6 +543,7 @@ if __name__ == "__main__":
     else:
         machine_iterable = read_lexicon(file(args.formula_or_lexicon), def_parser)
     # in some third case: print def_parser.parse(args.formula_or_lexicon)
-    if args.debug_machine:
-        for machine in machine_iterable:
-            print Machine.to_debug_str(machine)
+    for machine in machine_iterable:
+        debug_str = Machine.to_debug_str(machine)
+        if args.debug_machine:
+            print debug_str

--- a/src/pymachine/wrapper.py
+++ b/src/pymachine/wrapper.py
@@ -9,11 +9,10 @@ import sys
 from pymachine.construction import VerbConstruction
 from pymachine.sentence_parser import SentenceParser
 from pymachine.lexicon import Lexicon
-from pymachine.operators import AppendToBinaryFromLexiconOperator  # nopep8
 from pymachine.utils import ensure_dir, MachineGraph, MachineTraverser
 from pymachine.machine import Machine
 from pymachine.spreading_activation import SpreadingActivation
-from pymachine.definition_parser import read as read_defs
+from pymachine.definition_parser import read_defs
 from pymachine.sup_dic import supplementary_dictionary_reader as sdreader
 from pymachine import np_grammar
 

--- a/src/pymachine/wrapper.py
+++ b/src/pymachine/wrapper.py
@@ -79,7 +79,7 @@ class Wrapper:
             else:
                 logging.info('parsing 4lang definitions...')
                 definitions = read_defs(
-                    file(file_name), self.plural_fn, printname_index,
+                    file(file_name), printname_index=printname_index,
                     three_parts=True)
 
                 logging.info('dumping 4lang definitions to file...')


### PR DESCRIPTION
This has to be merged simultaneously with https://github.com/kornai/4lang/pull/132 (and replaces the closed https://github.com/kornai/pymachine/pull/13, because that belongs to a branch with a confusing name).

The changes can be summarized as follows:
- (hand-written) 4lang definitions are not allowed to contain plural forms, the mechanism for this is removed
- machines have a fix number of 3 partitions (0, 1, 2), the option for merging 0 and 1 has been removed
- the function that was called read (which was problematic, being a reserved name) is now called read_defs, and returns an iterator (the number of definitions is not logged in advance).

Tested (`python src/fourlang/lexicon.py conf/default.cfg`)
